### PR TITLE
Update serial_rts_dtr.c

### DIFF
--- a/serial_rts_dtr.c
+++ b/serial_rts_dtr.c
@@ -52,7 +52,7 @@
     	#include <unistd.h> 	 /* UNIX Standard Definitions 	       */ 
     	#include <errno.h>   	 /* ERROR Number Definitions           */
 	#include <sys/ioctl.h>   /* ioctl()                            */
-    	void main(void)
+    	int main(void)
     	{
         	int fd;	/*File Descriptor*/
 		


### PR DESCRIPTION
fixes warning
    serial_rts_dtr.c: In function ‘main’:
    serial_rts_dtr.c:56: warning: return type of ‘main’ is not ‘int’